### PR TITLE
Update GitInputs list to include branch heads recursively

### DIFF
--- a/src/GitInfo/build/GitInfo.targets
+++ b/src/GitInfo/build/GitInfo.targets
@@ -192,7 +192,7 @@
 			<_GitInput Include="$(GitDir)HEAD" />
 			<_GitInput Include="$(GitVersionFile)" Condition="Exists('$(GitVersionFile)')" />
 		</ItemGroup>
-		<CreateItem Include="$([System.IO.Path]::Combine('$(GitDir)', 'refs', 'heads', '*.*'))">
+		<CreateItem Include="$([System.IO.Path]::Combine('$(GitDir)', 'refs', 'heads', '**', '*.*'))">
 			<Output ItemName="_GitInput" TaskParameter="Include" />
 		</CreateItem>
 	</Target>


### PR DESCRIPTION
When branch name is using "foo/bar" format, git creates folders for each individual parts separated by "/". However GitInfo only watchs on the top level branch heads. This change would allow GitInfo to watch on all branch heads changes recursively.