### PR TITLE
track packed-refs as refs/heads may be empty when "packed-refs -all" have been used

### DIFF
--- a/src/GitInfo/build/GitInfo.targets
+++ b/src/GitInfo/build/GitInfo.targets
@@ -233,6 +233,9 @@
 			<_GitInput Include="$(GitDir)HEAD" />
 			<_GitInput Include="$(GitVersionFile)" Condition="Exists('$(GitVersionFile)')" />
 		</ItemGroup>
+		<CreateItem Include="$([System.IO.Path]::Combine('$(GitDir)', 'packed-refs'))">
+			<Output ItemName="_GitInput" TaskParameter="Include" />
+		</CreateItem>		
 		<CreateItem Include="$([System.IO.Path]::Combine('$(GitDir)', 'refs', 'heads', '**', '*.*'))">
 			<Output ItemName="_GitInput" TaskParameter="Include" />
 		</CreateItem>


### PR DESCRIPTION
fix #37 