### PR TITLE
Use MSBuildRuntimeTime to discern xbuild

### DIFF
--- a/src/GitInfo/build/GitInfo.targets
+++ b/src/GitInfo/build/GitInfo.targets
@@ -849,10 +849,10 @@
 		<WriteLinesToFile File='$(GitInfoThisAssemblyFile)' Lines='$(_ThisAssemblyContent)' Overwrite='true' />
 
 		<!-- Denotes xbuild, which doesn't properly handle escaped semicolon %3B -->
-		<Exec Condition="'$(MSBuildRuntimeVersion)' == '' AND '$(OS)' != 'Windows_NT'"
+		<Exec Condition="'$(MSBuildRuntimeType)' == ''"
 			  Command="sed 's/\(.*\)&quot;/\1&quot;;/' '$(GitInfoThisAssemblyFile)'" />
 		<!-- Remove potential double semi-colon we might have added -->
-		<Exec Condition="'$(MSBuildRuntimeVersion)' == '' AND '$(OS)' != 'Windows_NT'"
+		<Exec Condition="'$(MSBuildRuntimeType)' == ''"
 			  Command="sed 's/\(.*\)&quot;;;/\1&quot;;/' '$(GitInfoThisAssemblyFile)'" />
 
 	</Target>
@@ -895,7 +895,7 @@
 		<CygPathExe Condition="'$(CygPathExe)' == '' And Exists('C:\cygwin64\bin\cygpath.exe') And $(GitExe.Contains('cygwin64'))">C:\cygwin64\bin\cygpath.exe</CygPathExe>
 	</PropertyGroup>
 
-	<Import Project="GitInfo.xbuild" Condition="'$(MSBuildRuntimeVersion)' == '' AND '$(OS)' != 'Windows_NT'" />
+	<Import Project="GitInfo.xbuild" Condition="'$(MSBuildRuntimeType)' == ''" />
 
 	<Target Name="SetGitExe" Condition="'$(OS)' == 'Windows_NT'">
 		<!-- If git from %PATH% works, override the paths we calculated with that one instead -->


### PR DESCRIPTION
`MSBuildRuntimeTime` is never set by `xbuild`, but it can also be used to differentiate .NET Framework or .NET Core (e.g. it'll be `Core` on .NET Core).

This ensures GitInfo works under `dotnet build` and friends on macOS as well as Windows.

Improves upon PR #42. Thanks to @bojanrajkovic for the suggestion.