### PR TITLE
Add support for multi-targeting builds to retrieve Git information

### DIFF
--- a/src/GitInfo/GitInfo.nuspec
+++ b/src/GitInfo/GitInfo.nuspec
@@ -47,5 +47,6 @@ The generated code contains only constants, so it can be used to construct your 
     <file src="build\GitInfo.targets" target="build" />
     <file src="build\wslrun.cmd" target="build" />
     <file src="build\wslpath.cmd" target="build" />
+    <file src="buildMultiTargeting\GitInfo.targets" target="buildMultiTargeting" />
   </files>
 </package>

--- a/src/GitInfo/buildMultiTargeting/GitInfo.targets
+++ b/src/GitInfo/buildMultiTargeting/GitInfo.targets
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" InitialTargets="SetGitExe" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<Import Project="..\build\GitInfo.targets" />
+</Project>


### PR DESCRIPTION
Can be used for the SDK Pack target, for example, when the library is multi-targeting.