### PR TITLE
Fix for cygwin/WSL and add support for Windows Store WSL distros

### DIFF
--- a/src/GitInfo/build/GitInfo.targets
+++ b/src/GitInfo/build/GitInfo.targets
@@ -239,8 +239,20 @@
 			<Output TaskParameter="ExitCode" PropertyName="MSBuildLastExitCode" />
 		</Exec>
 
+		<!-- Account for cygwin/WSL separately -->
+		<Exec Command='"$(CygPathExe)" -w "$(_GitCommonDir)"' 
+			  EchoOff='true'
+			  WorkingDirectory="$(GitInfoBaseDir)"
+			  StandardErrorImportance='high'
+			  StandardOutputImportance='low'
+			  ConsoleToMSBuild='true'
+			  Condition="'$(_IsGitFile)' == 'true' and '$(_IsGitWorkTree)' == 'true' And '$(MSBuildLastExitCode)' == '0' And '$(CygPathExe)' != ''">
+			<Output TaskParameter="ConsoleOutput" PropertyName="_GitCommonDir" />
+			<Output TaskParameter="ExitCode" PropertyName="MSBuildLastExitCode" />
+		</Exec>
+
 		<PropertyGroup Condition="'$(_IsGitFile)' == 'true' and '$(_IsGitWorkTree)' == 'true'">
-			<GitDir>$(_GitCommonDir)</GitDir>
+			<GitDir>$(_GitCommonDir.Trim())</GitDir>
 		</PropertyGroup>
 
 		<PropertyGroup Condition="'$(_IsGitFile)' == 'true' and '$(_IsGitWorkTree)' != 'true'">

--- a/src/GitInfo/build/GitInfo.targets
+++ b/src/GitInfo/build/GitInfo.targets
@@ -880,41 +880,15 @@
               GitExe Property
 	
 	Cascading probing mechanism will try to locate an installed 
-	version of git, msysgit or cygwin git.
+	version of git, msysgit, WSL git or cygwin git.
 	============================================================
 	-->
-	<PropertyGroup Condition="'$(GitExe)' == '' And '$(OS)' == 'Windows_NT'">
-		<!-- We probe multiple places, with the first matching one winning -->
-		<GitExe Condition="'$(GitExe)' == '' And Exists('C:\Program Files\Git\bin\git.exe')">"C:\Program Files\Git\bin\git.exe"</GitExe>
-		<GitExe Condition="'$(GitExe)' == '' And Exists('C:\Program Files (x86)\Git\bin\git.exe')">"C:\Program Files (x86)\Git\bin\git.exe"</GitExe>
-		<GitExe Condition="'$(GitExe)' == '' And Exists('C:\msysgit\bin\git.exe')">C:\msysgit\bin\git.exe</GitExe>
-		<GitExe Condition="'$(GitExe)' == '' And Exists('$(LOCALAPPDATA)\lxss\rootfs\usr\bin\git')">$(MSBuildThisFileDirectory)wslrun.cmd git</GitExe>
-		<GitExe Condition="'$(GitExe)' == '' And Exists('C:\cygwin\bin\git.exe')">C:\cygwin\bin\git.exe</GitExe>
-		<GitExe Condition="'$(GitExe)' == '' And Exists('C:\cygwin64\bin\git.exe')">C:\cygwin64\bin\git.exe</GitExe>
-		<!-- Ultimately, just try the exe and hope it exists in the PATH already -->
-		<GitExe Condition="'$(GitExe)' == ''">git.exe</GitExe>
-	</PropertyGroup>
 	<PropertyGroup Condition="'$(GitExe)' == '' And '$(OS)' != 'Windows_NT'">
 		<GitExe>git</GitExe>
 	</PropertyGroup>
 
-	<!--
-	============================================================
-              CygPathExe Property
-	
-	If we are using cygwin git, we need to pipe the path to
-	cygpath to convert it into a Windows path. If the path is
-	already a Windows path, it will be returned unchanged.
-	============================================================
-	-->
-	<PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
-		<CygPathExe Condition="'$(CygPathExe)' == '' And Exists('$(LOCALAPPDATA)\lxss\rootfs\usr\bin\git') And $(GitExe.Contains('wslrun.cmd'))">$(MSBuildThisFileDirectory)wslpath.cmd</CygPathExe>
-		<CygPathExe Condition="'$(CygPathExe)' == '' And Exists('C:\cygwin\bin\cygpath.exe') And $(GitExe.Contains('cygwin'))">C:\cygwin\bin\cygpath.exe</CygPathExe>
-		<CygPathExe Condition="'$(CygPathExe)' == '' And Exists('C:\cygwin64\bin\cygpath.exe') And $(GitExe.Contains('cygwin64'))">C:\cygwin64\bin\cygpath.exe</CygPathExe>
-	</PropertyGroup>
-
-	<Target Name="SetGitExe" Condition="'$(OS)' == 'Windows_NT'">
-		<!-- If git from %PATH% works, override the paths we calculated with that one instead -->
+	<Target Name="SetGitExe" Condition="'$(GitExe)' == '' And '$(OS)' == 'Windows_NT'">
+		<!-- If git from %PATH% works, just use that -->
 		<Exec Command='git --version'
 			  EchoOff='true'
 			  ContinueOnError='true'
@@ -924,6 +898,47 @@
 		</Exec>
 		<PropertyGroup Condition="'$(MSBuildLastExitCode)' == '0'">
 			<GitExe>git</GitExe>
+		</PropertyGroup>
+
+		<PropertyGroup Condition="'$(GitExe)' == ''">
+			<!-- We probe multiple places, with the first matching one winning -->
+			<GitExe Condition="'$(GitExe)' == '' And Exists('C:\Program Files\Git\bin\git.exe')">"C:\Program Files\Git\bin\git.exe"</GitExe>
+			<GitExe Condition="'$(GitExe)' == '' And Exists('C:\Program Files (x86)\Git\bin\git.exe')">"C:\Program Files (x86)\Git\bin\git.exe"</GitExe>
+			<GitExe Condition="'$(GitExe)' == '' And Exists('C:\msysgit\bin\git.exe')">C:\msysgit\bin\git.exe</GitExe>
+		</PropertyGroup>
+
+		<!-- If we didn't find it in the PATH nor the above locations, check for git installed in WSL -->
+		<Exec Condition="'$(GitExe)' == ''"
+			  Command="$(MSBuildThisFileDirectory)wslrun.cmd git --version"
+			  EchoOff='true'
+			  ContinueOnError='true'
+			  StandardErrorImportance='high'
+			  StandardOutputImportance='low'>
+			<Output TaskParameter="ExitCode" PropertyName="MSBuildLastExitCode" />
+		</Exec>
+		<PropertyGroup Condition="'$(GitExe)' == '' And '$(MSBuildLastExitCode)' == '0'">
+			<GitExe>$(MSBuildThisFileDirectory)wslrun.cmd git</GitExe>
+			<CygPathExe>$(MSBuildThisFileDirectory)wslpath.cmd</CygPathExe>
+		</PropertyGroup>
+
+		<PropertyGroup Condition="'$(GitExe)' == ''">
+			<!-- Only consider cygwin as a last resort, as it tends to be slower -->
+			<GitExe Condition="'$(GitExe)' == '' And Exists('C:\cygwin\bin\git.exe')">C:\cygwin\bin\git.exe</GitExe>
+			<GitExe Condition="'$(GitExe)' == '' And Exists('C:\cygwin64\bin\git.exe')">C:\cygwin64\bin\git.exe</GitExe>
+		</PropertyGroup>
+
+		<!--
+		============================================================
+				CygPathExe Property
+
+		If we are using cygwin git, we need to pipe the path to
+		cygpath to convert it into a Windows path. If the path is
+		already a Windows path, it will be returned unchanged.
+		============================================================
+		-->
+		<PropertyGroup>
+			<CygPathExe Condition="'$(CygPathExe)' == '' And Exists('C:\cygwin\bin\cygpath.exe') And $(GitExe.Contains('cygwin'))">C:\cygwin\bin\cygpath.exe</CygPathExe>
+			<CygPathExe Condition="'$(CygPathExe)' == '' And Exists('C:\cygwin64\bin\cygpath.exe') And $(GitExe.Contains('cygwin64'))">C:\cygwin64\bin\cygpath.exe</CygPathExe>
 		</PropertyGroup>
 	</Target>
 


### PR DESCRIPTION
In the Fall Creators Update, WSL now supports different Linux distributions through the Windows Store. Unfortunately, this means the old method of probing `$(LOCALAPPDATA)\lxss\rootfs\usr\bin\git` to check if git is installed in WSL will no longer work. This patch refactors things so we now just try to run `git --version` from within the user's default WSL distro, the same way we probe for git on the Windows PATH. This should work with both the old and new WSL installations.