### PR TITLE
Extract label from branch path

### DIFF
--- a/src/GitInfo/build/GitInfo.targets
+++ b/src/GitInfo/build/GitInfo.targets
@@ -94,7 +94,7 @@
 			$(CoreCompileDependsOn)
 		</CoreCompileDependsOn>
 
-		<_GitBaseVersionExpr Condition="'$(_GitBaseVersionExpr)' == ''">^v?(?&lt;MAJOR&gt;\d+)\.(?&lt;MINOR&gt;\d+)\.(?&lt;PATCH&gt;\d+)(?:\-(?&lt;LABEL&gt;[\dA-Za-z\-\.]+))?$|^(?&lt;LABEL&gt;[\dA-Za-z\-\.]+)\-v?(?&lt;MAJOR&gt;\d+)\.(?&lt;MINOR&gt;\d+)\.(?&lt;PATCH&gt;\d+)$</_GitBaseVersionExpr>
+		<_GitBaseVersionExpr Condition="'$(_GitBaseVersionExpr)' == ''">^v?(?&lt;MAJOR&gt;\d+)\.(?&lt;MINOR&gt;\d+)\.(?&lt;PATCH&gt;\d+)(?:\-(?&lt;LABEL&gt;[\dA-Za-z\-\.]+))?$|^(?&lt;LABEL&gt;[\dA-Za-z\-\.]+)(?:\-|\/)(v?(?&lt;MAJOR&gt;\d+)\.(?&lt;MINOR&gt;\d+)\.(?&lt;PATCH&gt;\d+))$</_GitBaseVersionExpr>
 		<!-- Cache file used to avoid running all git commands. Only GitRoot will be retrieved to determine the path of this cache file. -->
 		<_GitInfoFile>$(IntermediateOutputPath)GitInfo.cache</_GitInfoFile>
 	</PropertyGroup>


### PR DESCRIPTION
Allow the label to be determined from a branch path i.e releases/v1.0.0