### PR TITLE
Don't cause MSBuild warnings 'expected' failures

### DIFF
--- a/src/GitInfo/build/GitInfo.targets
+++ b/src/GitInfo/build/GitInfo.targets
@@ -905,7 +905,8 @@
 		<Exec Command='git --version'
 			  EchoOff='true'
 			  ContinueOnError='true'
-			  StandardErrorImportance='high'
+			  IgnoreExitCode='true'
+			  StandardErrorImportance='low'
 			  StandardOutputImportance='low'>
 			<Output TaskParameter="ExitCode" PropertyName="MSBuildLastExitCode" />
 		</Exec>


### PR DESCRIPTION
It's expected that `git` won't be in %PATH% so in this scenario we should
not generate an `MSB3073` warning, nor write stderr as high importance.

This removes these lines from every build on windows for me:
```
1>'git' is not recognized as an internal or external command,
1>operable program or batch file.
1>C:\Users\almcgo\.nuget\packages\gitinfo\2.0.11\build\GitInfo.targets(897,3): warning MSB3073: The command "git --version" exited with code 9009.
```