### PR TITLE
Fix SemVer.Source not working in Visual Basic

### DIFF
--- a/src/GitInfo/build/GitInfo.vb.pp
+++ b/src/GitInfo/build/GitInfo.vb.pp
@@ -83,8 +83,8 @@ Namespace Global
                 ''' <summary>Label with dash prefix: $GitSemVerDashLabel$</summary>
                 Public Const DashLabel As String = "$GitSemVerDashLabel$"
 
-                ''' <summary>Label with dash prefix: $GitSemVerSource$</summary>
-                Public Const Source As String = "$GitSemVerVerSource$"
+                ''' <summary>Source: $GitSemVerSource$</summary>
+                Public Const Source As String = "$GitSemVerSource$"
             End Class
         End Class
     End Class


### PR DESCRIPTION
Because of the mistype in VB template, **ThisAssembly.Git.SemVer.Source** is not working for Visual Basic.