### PR TITLE
fixed #98

### DIFF
--- a/src/GitInfo/build/GitInfo.targets
+++ b/src/GitInfo/build/GitInfo.targets
@@ -176,7 +176,8 @@
 			  StandardOutputImportance='low'
 			  ConsoleToMSBuild='true'
 			  WorkingDirectory='$(GitInfoBaseDir)'
-			  ContinueOnError='true'>
+			  ContinueOnError='true'
+			  StdOutEncoding='utf-8'>
 			<Output TaskParameter="ConsoleOutput" PropertyName="_GitOutput"/>
 			<Output TaskParameter="ExitCode" PropertyName="MSBuildLastExitCode" />
 		</Exec>
@@ -192,7 +193,8 @@
 			  StandardErrorImportance='high'
 			  StandardOutputImportance='low'
 			  ConsoleToMSBuild='true'
-			  Condition="'$(MSBuildLastExitCode)' == '0' And '$(CygPathExe)' != ''">
+			  Condition="'$(MSBuildLastExitCode)' == '0' And '$(CygPathExe)' != ''"
+			  StdOutEncoding='utf-8'>
 			<Output TaskParameter="ConsoleOutput" PropertyName="_GitOutput" />
 			<Output TaskParameter="ExitCode" PropertyName="MSBuildLastExitCode" />
 		</Exec>
@@ -219,7 +221,8 @@
 			  StandardOutputImportance='low'
 			  ConsoleToMSBuild='true'
 			  WorkingDirectory='$(GitInfoBaseDir)'
-			  ContinueOnError='true'>
+			  ContinueOnError='true'
+			  StdOutEncoding='utf-8'>
 			<Output TaskParameter="ConsoleOutput" PropertyName="_GitIsWorkTree"/>
 			<Output TaskParameter="ExitCode" PropertyName="MSBuildLastExitCode" />
 		</Exec>
@@ -235,7 +238,8 @@
 			  StandardOutputImportance='low'
 			  ConsoleToMSBuild='true'
 			  WorkingDirectory='$(GitInfoBaseDir)'
-			  ContinueOnError='true'>
+			  ContinueOnError='true'
+			  StdOutEncoding='utf-8'>
 			<Output TaskParameter="ConsoleOutput" PropertyName="_GitCommonDir"/>
 			<Output TaskParameter="ExitCode" PropertyName="MSBuildLastExitCode" />
 		</Exec>
@@ -247,7 +251,8 @@
 			  StandardErrorImportance='high'
 			  StandardOutputImportance='low'
 			  ConsoleToMSBuild='true'
-			  Condition="'$(_IsGitFile)' == 'true' and '$(_IsGitWorkTree)' == 'true' And '$(MSBuildLastExitCode)' == '0' And '$(CygPathExe)' != ''">
+			  Condition="'$(_IsGitFile)' == 'true' and '$(_IsGitWorkTree)' == 'true' And '$(MSBuildLastExitCode)' == '0' And '$(CygPathExe)' != ''"
+			  StdOutEncoding='utf-8'>
 			<Output TaskParameter="ConsoleOutput" PropertyName="_GitCommonDir" />
 			<Output TaskParameter="ExitCode" PropertyName="MSBuildLastExitCode" />
 		</Exec>
@@ -272,7 +277,8 @@
 			  StandardErrorImportance="low"
 			  StandardOutputImportance="low"
 			  WorkingDirectory="$(GitRoot)"
-			  IgnoreExitCode="true">
+			  IgnoreExitCode="true"
+			  StdOutEncoding='utf-8'>
 			<Output TaskParameter="ExitCode" PropertyName="GitIsDirty" />
 		</Exec>
 	</Target>
@@ -355,7 +361,8 @@
 			  StandardOutputImportance="low"
 			  ConsoleToMSBuild="true"
 			  WorkingDirectory="$(GitRoot)"
-			  ContinueOnError="true">
+			  ContinueOnError="true"
+			  StdOutEncoding='utf-8'>
 			<Output TaskParameter="ConsoleOutput" PropertyName="GitBranch"/>
 		</Exec>
 
@@ -377,7 +384,8 @@
 			  StandardOutputImportance="low"
 			  ConsoleToMSBuild="true"
 			  WorkingDirectory="$(GitRoot)"
-			  ContinueOnError="true">
+			  ContinueOnError="true"
+			  StdOutEncoding='utf-8'>
 			<Output TaskParameter="ConsoleOutput" PropertyName="GitCommit"/>
 			<Output TaskParameter="ExitCode" PropertyName="MSBuildLastExitCode" />
 		</Exec>
@@ -392,7 +400,8 @@
 			  StandardOutputImportance="low"
 			  ConsoleToMSBuild="true"
 			  WorkingDirectory="$(GitRoot)"
-			  ContinueOnError="true">
+			  ContinueOnError="true"
+			  StdOutEncoding='utf-8'>
 			<Output TaskParameter="ConsoleOutput" PropertyName="GitSha"/>
 			<Output TaskParameter="ExitCode" PropertyName="MSBuildLastExitCode" />
 		</Exec>
@@ -462,7 +471,8 @@
 			  StandardErrorImportance='high'
 			  StandardOutputImportance='low'
 			  ConsoleToMSBuild='true'
-			  Condition="'$(MSBuildLastExitCode)' == '0' And '$(CygPathExe)' != ''">
+			  Condition="'$(MSBuildLastExitCode)' == '0' And '$(CygPathExe)' != ''"
+			  StdOutEncoding='utf-8'>
 			<Output TaskParameter="ConsoleOutput" PropertyName="_GitVersionFile" />
 			<Output TaskParameter="ExitCode" PropertyName="MSBuildLastExitCode" />
 		</Exec>
@@ -473,7 +483,8 @@
 			  StandardOutputImportance="low"
 			  ConsoleToMSBuild="true"
 			  WorkingDirectory="$(GitRoot)"
-			  ContinueOnError="true">
+			  ContinueOnError="true"
+			  StdOutEncoding='utf-8'>
 			<Output TaskParameter="ConsoleOutput" PropertyName="_GitLastBump"/>
 			<Output TaskParameter="ExitCode" PropertyName="MSBuildLastExitCode" />
 		</Exec>
@@ -500,7 +511,8 @@
 			  StandardErrorImportance='high'
 			  StandardOutputImportance='low'
 			  ConsoleToMSBuild='true'
-			  Condition="'$(MSBuildLastExitCode)' == '0' And '$(CygPathExe)' != '' And '$(_GitCommitsRelativeTo)' != ''">
+			  Condition="'$(MSBuildLastExitCode)' == '0' And '$(CygPathExe)' != '' And '$(_GitCommitsRelativeTo)' != ''"
+			  StdOutEncoding='utf-8'>
 			<Output TaskParameter="ConsoleOutput" PropertyName="_GitCommitsRelativeTo" />
 			<Output TaskParameter="ExitCode" PropertyName="MSBuildLastExitCode" />
 		</Exec>
@@ -512,7 +524,8 @@
 			  StandardOutputImportance="low"
 			  ConsoleToMSBuild="true"
 			  WorkingDirectory="$(GitRoot)"
-			  ContinueOnError="true">
+			  ContinueOnError="true"
+			  StdOutEncoding='utf-8'>
 			<Output TaskParameter="ConsoleOutput" PropertyName="GitCommits"/>
 			<Output TaskParameter="ExitCode" PropertyName="MSBuildLastExitCode" />
 		</Exec>
@@ -556,7 +569,8 @@
 			  StandardOutputImportance="low"
 			  ConsoleToMSBuild="true"
 			  WorkingDirectory="$(GitRoot)"
-			  ContinueOnError="true">
+			  ContinueOnError="true"
+			  StdOutEncoding='utf-8'>
 			<Output TaskParameter="ConsoleOutput" PropertyName="_GitForkPoint"/>
 			<Output TaskParameter="ExitCode" PropertyName="MSBuildLastExitCode" />
 		</Exec>
@@ -576,7 +590,8 @@
 			  StandardOutputImportance="low"
 			  ConsoleToMSBuild="true"
 			  WorkingDirectory="$(GitRoot)"
-			  ContinueOnError="true">
+			  ContinueOnError="true"
+			  StdOutEncoding='utf-8'>
 			<Output TaskParameter="ConsoleOutput" PropertyName="GitCommits"/>
 			<Output TaskParameter="ExitCode" PropertyName="MSBuildLastExitCode" />
 		</Exec>
@@ -596,7 +611,8 @@
 			  ConsoleToMSBuild="true"
 			  WorkingDirectory="$(GitRoot)"
 			  ContinueOnError="true"
-			  IgnoreExitCode="true">
+			  IgnoreExitCode="true"
+			  StdOutEncoding='utf-8'>
 			<Output TaskParameter="ConsoleOutput" PropertyName="GitBaseTag"/>
 			<Output TaskParameter="ExitCode" PropertyName="MSBuildLastExitCode" />
 		</Exec>
@@ -624,7 +640,8 @@
 			  StandardOutputImportance="low"
 			  ConsoleToMSBuild="true"
 			  WorkingDirectory="$(GitRoot)"
-			  ContinueOnError="true">
+			  ContinueOnError="true"
+			  StdOutEncoding='utf-8'>
 			<Output TaskParameter="ConsoleOutput" PropertyName="GitTag"/>
 			<Output TaskParameter="ExitCode" PropertyName="MSBuildLastExitCode" />
 		</Exec>
@@ -654,7 +671,8 @@
 			  StandardOutputImportance="low"
 			  ConsoleToMSBuild="true"
 			  WorkingDirectory="$(GitRoot)"
-			  ContinueOnError="true">
+			  ContinueOnError="true"
+			  StdOutEncoding='utf-8'>
 			<Output TaskParameter="ConsoleOutput" PropertyName="_GitBaseTagCommit"/>
 			<Output TaskParameter="ExitCode" PropertyName="MSBuildLastExitCode" />
 		</Exec>
@@ -666,7 +684,8 @@
 			  StandardOutputImportance="low"
 			  ConsoleToMSBuild="true"
 			  WorkingDirectory="$(GitRoot)"
-			  ContinueOnError="true">
+			  ContinueOnError="true"
+			  StdOutEncoding='utf-8'>
 			<Output TaskParameter="ConsoleOutput" PropertyName="GitCommits"/>
 			<Output TaskParameter="ExitCode" PropertyName="MSBuildLastExitCode" />
 		</Exec>
@@ -704,7 +723,8 @@
 			  StandardOutputImportance="low"
 			  ConsoleToMSBuild="true"
 			  WorkingDirectory="$(GitRoot)"
-			  ContinueOnError="true">
+			  ContinueOnError="true"
+			  StdOutEncoding='utf-8'>
 			<Output TaskParameter="ConsoleOutput" PropertyName="GitCommits"/>
 			<Output TaskParameter="ExitCode" PropertyName="MSBuildLastExitCode" />
 		</Exec>
@@ -940,7 +960,8 @@
 			  EchoOff='true'
 			  ContinueOnError='true'
 			  StandardErrorImportance='high'
-			  StandardOutputImportance='low'>
+			  StandardOutputImportance='low'
+			  StdOutEncoding='utf-8'>
 			<Output TaskParameter="ExitCode" PropertyName="MSBuildLastExitCode" />
 		</Exec>
 		<PropertyGroup Condition="'$(GitExe)' == '' And '$(MSBuildLastExitCode)' == '0'">


### PR DESCRIPTION
set all `Exec.StdOutEncoding='utf-8'` 

Problems:
1.When the solution is in a non-ASCII character set path, the solution cannot be compiled, and the exception message is:"System.IO.DirectoryNotFoundException"
![image](https://user-images.githubusercontent.com/6604230/78854872-000ecc00-7a55-11ea-9203-0f669ad66cfd.png)


2.When there are non-ASCII characters in the git commit information or branch name or tag, there are garbled characters in the automatically generated `ThisAssembly.g.cs`
![image](https://user-images.githubusercontent.com/6604230/78854890-0dc45180-7a55-11ea-85a1-4275a4ed9749.png)


After analysis, it was found that the above-mentioned problems were caused by the incorrect default encoding used by `msbuild.exe` or `dotnet msbuild` when executing the `Exec` task in `Target`.

Solution：
Specify the output encoding of all `Target->Exec` tasks as 'utf-8',append code to Exec:
```
StdOutEncoding='utf-8'
```