### PR TITLE
Add repository url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .nuget
 out
-/GitInfo.cache
+**/GitInfo.cache
 *.suo
+.vs/

--- a/src/GitInfo/build/GitInfo.cache.pp
+++ b/src/GitInfo/build/GitInfo.cache.pp
@@ -1,3 +1,4 @@
+GitRepositoryUrl=$GitRepositoryUrl$;
 GitBranch=$GitBranch$;
 GitCommit=$GitCommit$;
 GitSha=$GitSha$;

--- a/src/GitInfo/build/GitInfo.cs.pp
+++ b/src/GitInfo/build/GitInfo.cs.pp
@@ -5,6 +5,7 @@
 
 #if ADDMETADATA
 [assembly: System.Reflection.AssemblyMetadata("GitInfo.IsDirty", RootNamespace.ThisAssembly.Git.IsDirtyString)]
+[assembly: System.Reflection.AssemblyMetadata("GitInfo.RepositoryUrl", RootNamespace.ThisAssembly.Git.RepositoryUrl)]
 [assembly: System.Reflection.AssemblyMetadata("GitInfo.Branch", RootNamespace.ThisAssembly.Git.Branch)]
 [assembly: System.Reflection.AssemblyMetadata("GitInfo.Commit", RootNamespace.ThisAssembly.Git.Commit)]
 [assembly: System.Reflection.AssemblyMetadata("GitInfo.Sha", RootNamespace.ThisAssembly.Git.Sha)]
@@ -37,6 +38,9 @@ namespace _RootNamespace_
 
       /// <summary>IsDirtyString: $GitIsDirty$</summary>
       public const string IsDirtyString = "$GitIsDirty$";
+
+      /// <summary>Repository URL: $GitRepositoryUrl$</summary>
+      public const string RepositoryUrl = "$GitRepositoryUrl$";
 
       /// <summary>Branch: $GitBranch$</summary>
       public const string Branch = "$GitBranch$";

--- a/src/GitInfo/build/GitInfo.fs.pp
+++ b/src/GitInfo/build/GitInfo.fs.pp
@@ -10,6 +10,9 @@ module Git =
     /// <summary>IsDirtyString: $GitIsDirty$</summary>
     let [<Literal>] IsDirtyString = "$GitIsDirty$"
 
+    /// <summary>Repository URL: $GitRepositoryUrl$</summary>
+    let [<Literal>] RepositoryUrl = "$GitRepositoryUrl$"
+
     /// <summary>Branch: $GitBranch$</summary>
     let [<Literal>] Branch = "$GitBranch$"
 

--- a/src/GitInfo/build/GitInfo.targets
+++ b/src/GitInfo/build/GitInfo.targets
@@ -23,9 +23,9 @@
 							  for the ThisAssembly class.
 							  Defaults to the global namespace.
 							  
-	$(GitRemoteOrigin): name of remote to get repository url for.
-						Defaults to 'origin'.
-											
+	$(GitRemote): name of remote to get repository url for.
+				  Defaults to 'origin'.
+
 	$(GitDefaultBranch): determines the base branch used to 
 						 calculate commits on top of current branch.
 						 Defaults to 'master'.
@@ -58,8 +58,8 @@
 	-->
 
 	<PropertyGroup>
-		<!-- Remote origin for repository url -->
-		<GitRemoteOrigin Condition="'$(GitRemoteOrigin)' == ''">origin</GitRemoteOrigin>
+		<!-- Name of remote for repository url -->
+		<GitRemote Condition="'$(GitRemote)' == ''">origin</GitRemote>
 		<!-- GitVersionFile allows overriding tags/branch names as a source for base version information -->
 		<GitVersionFile Condition="'$(GitVersionFile)' == ''">GitInfo.txt</GitVersionFile>
 		<!-- Default the lookup directory to the project directory unless overriden -->
@@ -346,7 +346,7 @@
 			Inputs="@(_GitInput)"
 			Outputs="$(_GitInfoFile)">
 
-		<Exec Command="$(GitExe) config --get remote.$(GitRemoteOrigin).url"
+		<Exec Command="$(GitExe) config --get remote.$(GitRemote).url"
 			  Condition="'$(GitRepositoryUrl)' == ''"
 			  StandardErrorImportance="low"
 			  StandardOutputImportance="low"
@@ -359,7 +359,7 @@
 		</Exec>
 		
 		<Warning Condition="'$(MSBuildLastExitCode)' != '0'"
-				 Text="Could not retrieve repository url for remote '$(GitRemoteOrigin)'" />
+				 Text="Could not retrieve repository url for remote '$(GitRemote)'" />
 
 		<!--TODO: Sensible default for GitRepositoryUrl-->
 	</Target>

--- a/src/GitInfo/build/GitInfo.targets
+++ b/src/GitInfo/build/GitInfo.targets
@@ -55,6 +55,8 @@
 	-->
 
 	<PropertyGroup>
+		<!-- Remote origin for repository url -->
+		<GitRemoteOrigin Condition="'$(GitRemoteOrigin)' == ''">origin</GitRemoteOrigin>
 		<!-- GitVersionFile allows overriding tags/branch names as a source for base version information -->
 		<GitVersionFile Condition="'$(GitVersionFile)' == ''">GitInfo.txt</GitVersionFile>
 		<!-- Default the lookup directory to the project directory unless overriden -->
@@ -103,6 +105,7 @@
 		<Message Importance="$(GitInfoReportImportance)" Text="Git Info:
   GitInfoBaseDir:       $(GitInfoBaseDir)
   GitRoot:              $(GitRoot)
+  GitRepositoryUrl      $(GitRepositoryUrl)
   GitBranch:            $(GitBranch)
   GitCommit:            $(GitCommit)
   GitSha:               $(GitSha)
@@ -131,6 +134,7 @@
 			_GitInputs;
 			_GitClearCache;
 			_GitReadCache;
+			_GitRepositoryUrl;
 			_GitBranch;
 			_GitCommit;
 			_GitPopulateInfo;
@@ -313,6 +317,7 @@
 		</CreateItem>
 
 		<PropertyGroup>
+			<GitRepositoryUrl Condition="'$(GitRepositoryUrl)' == ''">%(GitInfo.GitRepositoryUrl)</GitRepositoryUrl>
 			<GitBranch Condition="'$(GitBranch)' == ''">%(GitInfo.GitBranch)</GitBranch>
 			<GitCommit Condition="'$(GitCommit)' == ''">%(GitInfo.GitCommit)</GitCommit>
 			<GitSha Condition="'$(GitSha)' == ''">%(GitInfo.GitSha)</GitSha>
@@ -330,6 +335,26 @@
 			<GitSemVerLabel Condition="'$(GitSemVerLabel)' == ''">%(GitInfo.GitSemVerLabel)</GitSemVerLabel>
 			<GitSemVerDashLabel Condition="'$(GitSemVerDashLabel)' == ''">%(GitInfo.GitSemVerDashLabel)</GitSemVerDashLabel>
 			<GitSemVerSource Condition="'$(GitSemVerSource)' == ''">%(GitInfo.GitSemVerSource)</GitSemVerSource>
+		</PropertyGroup>
+	</Target>
+
+	<Target Name="_GitRepositoryUrl" Returns="$(GitRepositoryUrl)" DependsOnTargets="_GitRoot"
+			Condition="'$(GitRoot)' != '' and '$(GitRepositoryUrl)' == ''"
+			Inputs="@(_GitInput)"
+			Outputs="$(_GitInfoFile)">
+
+		<Exec Command="$(GitExe) config --get remote.$(GitRemoteOrigin).url"
+			  Condition="'$(GitRepositoryUrl)' == ''"
+			  StandardErrorImportance="low"
+			  StandardOutputImportance="low"
+			  ConsoleToMSBuild="true"
+			  WorkingDirectory="$(GitRoot)"
+			  ContinueOnError="true">
+			<Output TaskParameter="ConsoleOutput" PropertyName="GitRepositoryUrl"/>
+		</Exec>
+
+		<PropertyGroup Condition="'$(MSBuildLastExitCode)' != '0'">
+			<GitSha>$(GitDefaultCommit)</GitSha>
 		</PropertyGroup>
 	</Target>
 
@@ -372,12 +397,12 @@
 			Condition="'$(GitRoot)' != '' And '$(GitCommit)' == ''">
 
 		<Exec Command='$(GitExe) -c log.showSignature=false log --format=format:$(_ShortShaFormat) -n 1'
-			  EchoOff='true'
-			  StandardErrorImportance="low"
-			  StandardOutputImportance="low"
-			  ConsoleToMSBuild="true"
-			  WorkingDirectory="$(GitRoot)"
-			  ContinueOnError="true">
+		      EchoOff='true'
+		      StandardErrorImportance="low"
+		      StandardOutputImportance="low"
+		      ConsoleToMSBuild="true"
+		      WorkingDirectory="$(GitRoot)"
+		      ContinueOnError="true">
 			<Output TaskParameter="ConsoleOutput" PropertyName="GitCommit"/>
 			<Output TaskParameter="ExitCode" PropertyName="MSBuildLastExitCode" />
 		</Exec>
@@ -406,6 +431,7 @@
 	<Target Name="_GitPopulateInfo">
 		<ItemGroup>
 			<GitInfo Include="GitInfo">
+				<GitRepositoryUrl>$(GitRepositoryUrl)</GitRepositoryUrl>
 				<GitRoot>$(GitRoot)</GitRoot>
 				<GitBranch>$(GitBranch)</GitBranch>
 				<GitCommit>$(GitCommit)</GitCommit>
@@ -780,7 +806,7 @@
 
 		<PropertyGroup>
 			<_GitInfoContent>$([System.IO.File]::ReadAllText('$(MSBuildThisFileDirectory)GitInfo.cache.pp'))</_GitInfoContent>
-
+			<_GitInfoContent>$(_GitInfoContent.Replace('$GitRepositoryUrl$', '$(GitRepositoryUrl)'))</_GitInfoContent>
 			<_GitInfoContent>$(_GitInfoContent.Replace('$GitBranch$', '$(GitBranch)'))</_GitInfoContent>
 			<_GitInfoContent>$(_GitInfoContent.Replace('$GitCommits$', '$(GitCommits)'))</_GitInfoContent>
 			<_GitInfoContent>$(_GitInfoContent.Replace('$GitCommit$', '$(GitCommit)'))</_GitInfoContent>

--- a/src/GitInfo/build/GitInfo.targets
+++ b/src/GitInfo/build/GitInfo.targets
@@ -22,6 +22,9 @@
 	$(ThisAssemblyNamespace): allows overriding the namespace
 							  for the ThisAssembly class.
 							  Defaults to the global namespace.
+							  
+	$(GitRemoteOrigin): name of remote to get repository url for.
+						Defaults to 'origin'.
 											
 	$(GitDefaultBranch): determines the base branch used to 
 						 calculate commits on top of current branch.
@@ -896,7 +899,8 @@
 			<_ThisAssemblyContent Condition="'$(Language)' == 'VB' And '$(GitRoot)' == ''">$(_ThisAssemblyContent.Replace('$GitIsDirty$', 'False'))</_ThisAssemblyContent>
 			<_ThisAssemblyContent Condition="'$(Language)' == 'VB' And '$(GitIsDirty)' == '1'">$(_ThisAssemblyContent.Replace('$GitIsDirty$', 'True'))</_ThisAssemblyContent>
 			<_ThisAssemblyContent Condition="'$(Language)' == 'VB' And '$(GitIsDirty)' == '0'">$(_ThisAssemblyContent.Replace('$GitIsDirty$', 'False'))</_ThisAssemblyContent>
-			
+
+			<_ThisAssemblyContent>$(_ThisAssemblyContent.Replace('$GitRepositoryUrl$', '$(GitRepositoryUrl)'))</_ThisAssemblyContent>
 			<_ThisAssemblyContent>$(_ThisAssemblyContent.Replace('$GitBranch$', '$(GitBranch)'))</_ThisAssemblyContent>
 			<_ThisAssemblyContent>$(_ThisAssemblyContent.Replace('$GitCommits$', '$(GitCommits)'))</_ThisAssemblyContent>
 			<_ThisAssemblyContent>$(_ThisAssemblyContent.Replace('$GitCommit$', '$(GitCommit)'))</_ThisAssemblyContent>

--- a/src/GitInfo/build/GitInfo.targets
+++ b/src/GitInfo/build/GitInfo.targets
@@ -400,12 +400,12 @@
 			Condition="'$(GitRoot)' != '' And '$(GitCommit)' == ''">
 
 		<Exec Command='$(GitExe) -c log.showSignature=false log --format=format:$(_ShortShaFormat) -n 1'
-		      EchoOff='true'
-		      StandardErrorImportance="low"
-		      StandardOutputImportance="low"
-		      ConsoleToMSBuild="true"
-		      WorkingDirectory="$(GitRoot)"
-		      ContinueOnError="true">
+			  EchoOff='true'
+			  StandardErrorImportance="low"
+			  StandardOutputImportance="low"
+			  ConsoleToMSBuild="true"
+			  WorkingDirectory="$(GitRoot)"
+			  ContinueOnError="true">
 			<Output TaskParameter="ConsoleOutput" PropertyName="GitCommit"/>
 			<Output TaskParameter="ExitCode" PropertyName="MSBuildLastExitCode" />
 		</Exec>

--- a/src/GitInfo/build/GitInfo.targets
+++ b/src/GitInfo/build/GitInfo.targets
@@ -352,13 +352,16 @@
 			  StandardOutputImportance="low"
 			  ConsoleToMSBuild="true"
 			  WorkingDirectory="$(GitRoot)"
-			  ContinueOnError="true">
+			  ContinueOnError="true"
+			  IgnoreExitCode="true">
 			<Output TaskParameter="ConsoleOutput" PropertyName="GitRepositoryUrl"/>
+			<Output TaskParameter="ExitCode" PropertyName="MSBuildLastExitCode"/>
 		</Exec>
+		
+		<Warning Condition="'$(MSBuildLastExitCode)' != '0'"
+				 Text="Could not retrieve repository url for remote '$(GitRemoteOrigin)'" />
 
-		<PropertyGroup Condition="'$(MSBuildLastExitCode)' != '0'">
-			<GitSha>$(GitDefaultCommit)</GitSha>
-		</PropertyGroup>
+		<!--TODO: Sensible default for GitRepositoryUrl-->
 	</Target>
 
 	<Target Name="_GitBranch" Returns="$(GitBranch)"

--- a/src/GitInfo/build/GitInfo.vb.pp
+++ b/src/GitInfo/build/GitInfo.vb.pp
@@ -4,6 +4,7 @@
 
 #If ADDMETADATA
 <Assembly: System.Reflection.AssemblyMetadata("GitInfo.IsDirty", Global.RootNamespace.ThisAssembly.Git.IsDirtyString)>
+<Assembly: System.Reflection.AssemblyMetadata("GitInfo.RepositoryUrl", Global.RootNamespace.ThisAssembly.Git.RepositoryUrl)>
 <Assembly: System.Reflection.AssemblyMetadata("GitInfo.Branch", Global.RootNamespace.ThisAssembly.Git.Branch)>
 <Assembly: System.Reflection.AssemblyMetadata("GitInfo.Commit", Global.RootNamespace.ThisAssembly.Git.Commit)>
 <Assembly: System.Reflection.AssemblyMetadata("GitInfo.Sha", Global.RootNamespace.ThisAssembly.Git.Sha)>
@@ -35,6 +36,9 @@ Namespace Global
 
             ''' <summary>IsDirtyString: $GitIsDirty$</summary>
             Public Const IsDirtyString As String = "$GitIsDirty$"
+
+            ''' <summary>Repository URL: $GitRepositoryUrl$</summary>
+            Public Const RepositoryUrl As String = "$GitRepositoryUrl$"
 
             ''' <summary>Branch: $GitBranch$</summary>
             Public Const Branch As String = "$GitBranch$"

--- a/src/GitInfo/readme.txt
+++ b/src/GitInfo/readme.txt
@@ -74,8 +74,8 @@ Available MSBuild customizations:
                             for the ThisAssembly class.
                             Defaults to the global namespace.
 
-  $(GitRemoteOrigin): name of remote to get repository url for.
-                      Defaults to 'origin'.
+  $(GitRemote): name of remote to get repository url for.
+                Defaults to 'origin'.
 
   $(GitDefaultBranch): determines the base branch used to 
                        calculate commits on top of current branch.

--- a/src/GitInfo/readme.txt
+++ b/src/GitInfo/readme.txt
@@ -44,6 +44,7 @@ it very easy to see what the different values contain.
 
 The available constants from code are:
 
+  ThisAssembly.Git.RepositoryUrl
   ThisAssembly.Git.Branch
   ThisAssembly.Git.Commit
   ThisAssembly.Git.Commits

--- a/src/GitInfo/readme.txt
+++ b/src/GitInfo/readme.txt
@@ -3,6 +3,7 @@ Git Info from MSBuild, C# and VB
 Exposes the following information for use directly from any MSBuild 
 target that depends on the GitInfo target:
 
+  $(GitRepositoryUrl)
   $(GitBranch)
   $(GitCommit)
   $(GitCommits)
@@ -72,6 +73,9 @@ Available MSBuild customizations:
   $(ThisAssemblyNamespace): allows overriding the namespace
                             for the ThisAssembly class.
                             Defaults to the global namespace.
+
+  $(GitRemoteOrigin): name of remote to get repository url for.
+                      Defaults to 'origin'.
 
   $(GitDefaultBranch): determines the base branch used to 
                        calculate commits on top of current branch.


### PR DESCRIPTION
Fix #109

## Added
* Get repository url from remote. Default is 'origin'. Can be configured via ~GitRemoteOrigin~ GitRemote

## Proposal
* Write full url "$(GitRepositoryUrl)/tree/$(Commit)" (default) that the assembly was built from

## Task
- [x] Change GitRemoteOrigin to GitRemote
- [ ] Default for GitRepositoryUrl? "http://localhost"
- [x] Handle failure getting url
- [ ] Rebase before merge
- [ ] Merge style (squash, rebase-fastforward, ..)
- ~Add default remote name~ Set default origin early
 