### PR TITLE
Fix GitThisAssemblyMetadata

### DIFF
--- a/src/GitInfo/build/GitInfo.targets
+++ b/src/GitInfo/build/GitInfo.targets
@@ -66,6 +66,8 @@
 		<GitDefaultCommit Condition="'$(GitDefaultCommit)' == ''">0000000</GitDefaultCommit>
 		<GitDefaultVersion Condition="'$(GitDefaultVersion)' == ''">0.0.0</GitDefaultVersion>
 
+		<GitThisAssemblyMetadata Condition="'$(GitThisAssemblyMetadata)' == ''">false</GitThisAssemblyMetadata>
+
 		<GitInfoThisAssemblyFile Condition="'$(GitInfoThisAssemblyFile)' == '' And '$(DefaultLanguageSourceExtension)' != ''">$(IntermediateOutputPath)ThisAssembly.GitInfo.g$(DefaultLanguageSourceExtension)</GitInfoThisAssemblyFile>
 		<GitThisAssembly Condition="'$(Language)' != 'C#' And '$(Language)' != 'F#' And '$(Language)' != 'VB'">false</GitThisAssembly>
 		<GitThisAssembly Condition="'$(GitThisAssembly)' == '' And '$(GitInfoThisAssemblyFile)' != ''">true</GitThisAssembly>


### PR DESCRIPTION
Fix #108 by explicitly declaring property before used. Default behavior is preserved by defaulting to false. Attached sample program and NuGet

## Environment
```
$ dotnet --version
3.1.300-preview-015048
$ dotnet msbuild --help
Microsoft (R) Build Engine version 16.6.0-preview-20162-03+00781ad13 for .NET Core
```

[CSharp.zip](https://github.com/kzu/GitInfo/files/4502539/CSharp.zip)