### PR TITLE
Add support for C++

### DIFF
--- a/src/GitInfo.sln
+++ b/src/GitInfo.sln
@@ -15,6 +15,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "GitInfo", "GitInfo", "{66BB
 		GitInfo\build\GitInfo.cs.pp = GitInfo\build\GitInfo.cs.pp
 		GitInfo\build\GitInfo.fs.pp = GitInfo\build\GitInfo.fs.pp
 		GitInfo\GitInfo.nuspec = GitInfo\GitInfo.nuspec
+		GitInfo\build\GitInfo.pdef.pp = GitInfo\build\GitInfo.pdef.pp
 		GitInfo\build\GitInfo.targets = GitInfo\build\GitInfo.targets
 		GitInfo\build\GitInfo.vb.pp = GitInfo\build\GitInfo.vb.pp
 		GitInfo\build\GitInfo.xbuild = GitInfo\build\GitInfo.xbuild

--- a/src/GitInfo/GitInfo.nuspec
+++ b/src/GitInfo/GitInfo.nuspec
@@ -45,6 +45,7 @@ The generated code contains only constants, so it can be used to construct your 
     <file src="build\GitInfo.cs.pp" target="build" />
     <file src="build\GitInfo.fs.pp" target="build" />
     <file src="build\GitInfo.vb.pp" target="build" />
+    <file src="build\GitInfo.pdef.pp" target="build" />
     <file src="build\GitInfo.targets" target="build" />
     <file src="buildMultiTargeting\GitInfo.targets" target="buildMultiTargeting" />
     <file src="build\wslrun.cmd" target="build" />

--- a/src/GitInfo/build/GitInfo.pdef.pp
+++ b/src/GitInfo/build/GitInfo.pdef.pp
@@ -1,0 +1,17 @@
+GIT_ISDIRTY=$GitIsDirty$
+GIT_REPOSITORYURL="$GitRepositoryUrl$"
+GIT_BRANCH="$GitBranch$"
+GIT_COMMIT="$GitCommit$"
+GIT_SHA="$GitSha$"
+GIT_COMMITS=$GitCommits$
+GIT_TAG="$GitTag$"
+GIT_BASETAG="$GitBaseTag$"
+GIT_BASEVERSION_MAJOR=$GitBaseVersionMajor$
+GIT_BASEVERSION_MINOR=$GitBaseVersionMinor$
+GIT_BASEVERSION_PATCH=$GitBaseVersionPatch$
+GIT_SEMVER_MAJOR=$GitSemVerMajor$
+GIT_SEMVER_MINOR=$GitSemVerMinor$
+GIT_SEMVER_PATCH=$GitSemVerPatch$
+GIT_SEMVER_LABEL="$GitSemVerLabel$"
+GIT_SEMVER_DASHLABEL="$GitSemVerDashLabel$"
+GIT_SEMVER_SOURCE="$GitSemVerSource$"

--- a/src/GitInfo/build/GitInfo.targets
+++ b/src/GitInfo/build/GitInfo.targets
@@ -23,6 +23,9 @@
 							  for the ThisAssembly class.
 							  Defaults to the global namespace.
 							  
+	$(GitPreprocessorDefinitions): set to 'false' to prevent C++
+								   preprocessor definitions generation.
+
 	$(GitRemote): name of remote to get repository url for.
 				  Defaults to 'origin'.
 
@@ -79,6 +82,9 @@
 		<GitInfoReportImportance Condition="'$(GitInfoReportImportance)' == ''">low</GitInfoReportImportance>
 		<GitThisAssemblyMetadataDefine Condition="'$(GitThisAssemblyMetadata)' == 'true'">ADDMETADATA</GitThisAssemblyMetadataDefine>
 		<GitThisAssemblyMetadataDefine Condition="'$(GitThisAssemblyMetadata)' != 'true'">NOMETADATA</GitThisAssemblyMetadataDefine>
+
+		<GitPreprocessorDefinitions Condition="'$(Language)' != 'C++'">false</GitPreprocessorDefinitions>
+		<GitPreprocessorDefinitions Condition="'$(GitPreprocessorDefinitions)' == ''">true</GitPreprocessorDefinitions>
 
 		<!-- Defaults if overrides are specified when building -->
 		<GitCommits Condition="'$(GitCommits)' == ''">0</GitCommits>
@@ -953,6 +959,59 @@
 		<MakeDir Directories="$(GitInfoThisAssemblyDir)" Condition="!Exists('$(GitInfoThisAssemblyDir)')" />
 
 		<WriteLinesToFile File='$(GitInfoThisAssemblyFile)' Lines='$(_ThisAssemblyContent)' Overwrite='true' />
+	</Target>
+
+	<PropertyGroup>
+		<GitPreprocessorDefinitionsDependsOn>
+			GitInfo;
+			GitVersion;
+			_GitInputs;
+			_GitGeneratePreprocessorDefinitions
+		</GitPreprocessorDefinitionsDependsOn>
+	</PropertyGroup>
+
+	<Target Name="GitPreprocessorDefinitions" DependsOnTargets="$(GitPreprocessorDefinitionsDependsOn)"
+			BeforeTargets="_PrepareForBuild" Condition="'$(GitPreprocessorDefinitions)' == 'true'">
+		<ItemGroup>
+			<ClCompile>
+				<PreprocessorDefinitions>$(_PreprocessorDefinitionsContent);%(PreprocessorDefinitions)</PreprocessorDefinitions>
+			</ClCompile>
+			<ResourceCompile>
+				<PreprocessorDefinitions>$(_PreprocessorDefinitionsContent);%(PreprocessorDefinitions)</PreprocessorDefinitions>
+			</ResourceCompile>
+		</ItemGroup>
+	</Target>
+
+	<Target Name="_GitGeneratePreprocessorDefinitions" Condition="'$(GitPreprocessorDefinitions)' == 'true'">
+		<PropertyGroup>
+			<_PreprocessorDefinitionsContent>$([System.IO.File]::ReadAllText('$(MSBuildThisFileDirectory)GitInfo.pdef.pp'))</_PreprocessorDefinitionsContent>
+
+			<!-- no git repository -->
+			<_PreprocessorDefinitionsContent Condition="'$(GitRoot)' == ''">$(_PreprocessorDefinitionsContent.Replace('$GitIsDirty$', '0'))</_PreprocessorDefinitionsContent>
+			<_PreprocessorDefinitionsContent Condition="'$(GitIsDirty)' == '1'">$(_PreprocessorDefinitionsContent.Replace('$GitIsDirty$', '1'))</_PreprocessorDefinitionsContent>
+			<_PreprocessorDefinitionsContent Condition="'$(GitIsDirty)' == '0'">$(_PreprocessorDefinitionsContent.Replace('$GitIsDirty$', '0'))</_PreprocessorDefinitionsContent>
+
+			<_PreprocessorDefinitionsContent>$(_PreprocessorDefinitionsContent.Replace('$GitRepositoryUrl$', '$(GitRepositoryUrl)'))</_PreprocessorDefinitionsContent>
+			<_PreprocessorDefinitionsContent>$(_PreprocessorDefinitionsContent.Replace('$GitBranch$', '$(GitBranch)'))</_PreprocessorDefinitionsContent>
+			<_PreprocessorDefinitionsContent>$(_PreprocessorDefinitionsContent.Replace('$GitCommits$', '$(GitCommits)'))</_PreprocessorDefinitionsContent>
+			<_PreprocessorDefinitionsContent>$(_PreprocessorDefinitionsContent.Replace('$GitCommit$', '$(GitCommit)'))</_PreprocessorDefinitionsContent>
+			<_PreprocessorDefinitionsContent>$(_PreprocessorDefinitionsContent.Replace('$GitSha$', '$(GitSha)'))</_PreprocessorDefinitionsContent>
+			<_PreprocessorDefinitionsContent>$(_PreprocessorDefinitionsContent.Replace('$GitBaseVersion$', '$(GitBaseVersion)'))</_PreprocessorDefinitionsContent>
+			<_PreprocessorDefinitionsContent>$(_PreprocessorDefinitionsContent.Replace('$GitBaseVersionSource$', '$(GitBaseVersionSource)'))</_PreprocessorDefinitionsContent>
+			<_PreprocessorDefinitionsContent>$(_PreprocessorDefinitionsContent.Replace('$GitBaseVersionMajor$', '$(GitBaseVersionMajor)'))</_PreprocessorDefinitionsContent>
+			<_PreprocessorDefinitionsContent>$(_PreprocessorDefinitionsContent.Replace('$GitBaseVersionMinor$', '$(GitBaseVersionMinor)'))</_PreprocessorDefinitionsContent>
+			<_PreprocessorDefinitionsContent>$(_PreprocessorDefinitionsContent.Replace('$GitBaseVersionPatch$', '$(GitBaseVersionPatch)'))</_PreprocessorDefinitionsContent>
+			<_PreprocessorDefinitionsContent>$(_PreprocessorDefinitionsContent.Replace('$GitTag$', '$(GitTag)'))</_PreprocessorDefinitionsContent>
+			<_PreprocessorDefinitionsContent>$(_PreprocessorDefinitionsContent.Replace('$GitBaseTag$', '$(GitBaseTag)'))</_PreprocessorDefinitionsContent>
+			<_PreprocessorDefinitionsContent>$(_PreprocessorDefinitionsContent.Replace('$GitSemVerMajor$', '$(GitSemVerMajor)'))</_PreprocessorDefinitionsContent>
+			<_PreprocessorDefinitionsContent>$(_PreprocessorDefinitionsContent.Replace('$GitSemVerMinor$', '$(GitSemVerMinor)'))</_PreprocessorDefinitionsContent>
+			<_PreprocessorDefinitionsContent>$(_PreprocessorDefinitionsContent.Replace('$GitSemVerPatch$', '$(GitSemVerPatch)'))</_PreprocessorDefinitionsContent>
+			<_PreprocessorDefinitionsContent>$(_PreprocessorDefinitionsContent.Replace('$GitSemVerLabel$', '$(GitSemVerLabel)'))</_PreprocessorDefinitionsContent>
+			<_PreprocessorDefinitionsContent>$(_PreprocessorDefinitionsContent.Replace('$GitSemVerDashLabel$', '$(GitSemVerDashLabel)'))</_PreprocessorDefinitionsContent>
+			<_PreprocessorDefinitionsContent>$(_PreprocessorDefinitionsContent.Replace('$GitSemVerSource$', '$(GitSemVerSource)'))</_PreprocessorDefinitionsContent>
+
+			<_PreprocessorDefinitionsContent>$(_PreprocessorDefinitionsContent.Split('%0A'))</_PreprocessorDefinitionsContent>
+		</PropertyGroup>
 	</Target>
 
 	<!--


### PR DESCRIPTION
Add preprocessor definitions (macros) with git info to C++ and resource compiler.

Using this way is because there's no easy way to inject global variables into a source file. Users are required to include a header in order to use generated git info.
And C++ has multiple char types, for example `"str"` is `char[]` and `L"str"` `wchar_t[]`. And there's no easy way to do a compile-time conversion.
But with macros, we can just use a macro like `#define WSTRIFY(s) L##s` to make it become `wchar_t[]`
Also the resource compiler doesn't support global variables, but macros are supported.

Currently there's a issue that Visual Studio says `identifier "GIT_*" is undefined`. A solution is to write a stub header file that checks existence these macros and define them if not exist.

Another option is to generate a header file with preprocessor definitions, and let user manually include it. Which one is better?

May closes #67, but I'm not familiar with managed C++.