### PR TITLE
Use verbatim string literals in C# and F# templates

### DIFF
--- a/src/GitInfo/build/GitInfo.cs.pp
+++ b/src/GitInfo/build/GitInfo.cs.pp
@@ -37,62 +37,62 @@ namespace _RootNamespace_
       public const bool IsDirty = $GitIsDirty$;
 
       /// <summary>IsDirtyString: $GitIsDirty$</summary>
-      public const string IsDirtyString = "$GitIsDirty$";
+      public const string IsDirtyString = @"$GitIsDirty$";
 
       /// <summary>Repository URL: $GitRepositoryUrl$</summary>
-      public const string RepositoryUrl = "$GitRepositoryUrl$";
+      public const string RepositoryUrl = @"$GitRepositoryUrl$";
 
       /// <summary>Branch: $GitBranch$</summary>
-      public const string Branch = "$GitBranch$";
+      public const string Branch = @"$GitBranch$";
 
       /// <summary>Commit: $GitCommit$</summary>
-      public const string Commit = "$GitCommit$";
+      public const string Commit = @"$GitCommit$";
 
       /// <summary>Sha: $GitSha$</summary>
-      public const string Sha = "$GitSha$";
+      public const string Sha = @"$GitSha$";
 
       /// <summary>Commits on top of base version: $GitCommits$</summary>
-      public const string Commits = "$GitCommits$";
+      public const string Commits = @"$GitCommits$";
 
       /// <summary>Tag: $GitTag$</summary>
-      public const string Tag = "$GitTag$";
+      public const string Tag = @"$GitTag$";
 
       /// <summary>Base tag: $GitBaseTag$</summary>
-      public const string BaseTag = "$GitBaseTag$";
+      public const string BaseTag = @"$GitBaseTag$";
 
       /// <summary>Provides access to the base version information used to determine the <see cref="SemVer" />.</summary>      
       public partial class BaseVersion
       {
         /// <summary>Major: $GitBaseVersionMajor$</summary>
-        public const string Major = "$GitBaseVersionMajor$";
+        public const string Major = @"$GitBaseVersionMajor$";
 
         /// <summary>Minor: $GitBaseVersionMinor$</summary>
-        public const string Minor = "$GitBaseVersionMinor$";
+        public const string Minor = @"$GitBaseVersionMinor$";
 
         /// <summary>Patch: $GitBaseVersionPatch$</summary>
-        public const string Patch = "$GitBaseVersionPatch$";
+        public const string Patch = @"$GitBaseVersionPatch$";
       }
 
       /// <summary>Provides access to SemVer information for the current assembly.</summary>
       public partial class SemVer
       {
         /// <summary>Major: $GitSemVerMajor$</summary>
-        public const string Major = "$GitSemVerMajor$";
+        public const string Major = @"$GitSemVerMajor$";
 
         /// <summary>Minor: $GitSemVerMinor$</summary>
-        public const string Minor = "$GitSemVerMinor$";
+        public const string Minor = @"$GitSemVerMinor$";
 
         /// <summary>Patch: $GitSemVerPatch$</summary>
-        public const string Patch = "$GitSemVerPatch$";
+        public const string Patch = @"$GitSemVerPatch$";
 
         /// <summary>Label: $GitSemVerLabel$</summary>
-        public const string Label = "$GitSemVerLabel$";
+        public const string Label = @"$GitSemVerLabel$";
 
         /// <summary>Label with dash prefix: $GitSemVerDashLabel$</summary>
-        public const string DashLabel = "$GitSemVerDashLabel$";
+        public const string DashLabel = @"$GitSemVerDashLabel$";
 
         /// <summary>Source: $GitSemVerSource$</summary>
-        public const string Source = "$GitSemVerSource$";
+        public const string Source = @"$GitSemVerSource$";
       }
     }
   }

--- a/src/GitInfo/build/GitInfo.fs.pp
+++ b/src/GitInfo/build/GitInfo.fs.pp
@@ -8,57 +8,57 @@ module Git =
     let [<Literal>] IsDirty = $GitIsDirty$
 
     /// <summary>IsDirtyString: $GitIsDirty$</summary>
-    let [<Literal>] IsDirtyString = "$GitIsDirty$"
+    let [<Literal>] IsDirtyString = @"$GitIsDirty$"
 
     /// <summary>Repository URL: $GitRepositoryUrl$</summary>
-    let [<Literal>] RepositoryUrl = "$GitRepositoryUrl$"
+    let [<Literal>] RepositoryUrl = @"$GitRepositoryUrl$"
 
     /// <summary>Branch: $GitBranch$</summary>
-    let [<Literal>] Branch = "$GitBranch$"
+    let [<Literal>] Branch = @"$GitBranch$"
 
     /// <summary>Commit: $GitCommit$</summary>
-    let [<Literal>] Commit = "$GitCommit$"
+    let [<Literal>] Commit = @"$GitCommit$"
 
     /// <summary>Sha: $GitSha$</summary>
-    let [<Literal>] Sha = "$GitSha$"
+    let [<Literal>] Sha = @"$GitSha$"
 
     /// <summary>Commits on top of base version: $GitCommits$</summary>
-    let [<Literal>] Commits = "$GitCommits$"
+    let [<Literal>] Commits = @"$GitCommits$"
 
     /// <summary>Tag: $GitTag$</summary>
-    let [<Literal>] Tag = "$GitTag$"
+    let [<Literal>] Tag = @"$GitTag$"
 
     /// <summary>Base tag: $GitBaseTag$</summary>
-    let [<Literal>] BaseTag = "$GitBaseTag$"
+    let [<Literal>] BaseTag = @"$GitBaseTag$"
 
     /// <summary>Provides access to the base version information used to determine the <see cref="SemVer" />.</summary>      
     module BaseVersion =
         /// <summary>Major: $GitBaseVersionMajor$</summary>
-        let [<Literal>] Major = "$GitBaseVersionMajor$"
+        let [<Literal>] Major = @"$GitBaseVersionMajor$"
 
         /// <summary>Minor: $GitBaseVersionMinor$</summary>
-        let [<Literal>] Minor = "$GitBaseVersionMinor$"
+        let [<Literal>] Minor = @"$GitBaseVersionMinor$"
 
         /// <summary>Patch: $GitBaseVersionPatch$</summary>
-        let [<Literal>] Patch = "$GitBaseVersionPatch$"
+        let [<Literal>] Patch = @"$GitBaseVersionPatch$"
 
 
     /// <summary>Provides access to SemVer information for the current assembly.</summary>
     module SemVer =
         /// <summary>Major: $GitSemVerMajor$</summary>
-        let [<Literal>] Major = "$GitSemVerMajor$"
+        let [<Literal>] Major = @"$GitSemVerMajor$"
 
         /// <summary>Minor: $GitSemVerMinor$</summary>
-        let [<Literal>] Minor = "$GitSemVerMinor$"
+        let [<Literal>] Minor = @"$GitSemVerMinor$"
 
         /// <summary>Patch: $GitSemVerPatch$</summary>
-        let [<Literal>] Patch = "$GitSemVerPatch$"
+        let [<Literal>] Patch = @"$GitSemVerPatch$"
 
         /// <summary>Label: $GitSemVerLabel$</summary>
-        let [<Literal>] Label = "$GitSemVerLabel$"
+        let [<Literal>] Label = @"$GitSemVerLabel$"
 
         /// <summary>Label with dash prefix: $GitSemVerDashLabel$</summary>
-        let [<Literal>] DashLabel = "$GitSemVerDashLabel$"
+        let [<Literal>] DashLabel = @"$GitSemVerDashLabel$"
 
         /// <summary>Source: $GitSemVerSource$</summary>
-        let [<Literal>] Source = "$GitSemVerSource$"
+        let [<Literal>] Source = @"$GitSemVerSource$"


### PR DESCRIPTION
This fixes #119 by using verbatim string literals in the GitInfo C# and F# templates.  No change is needed for VB since it does not use escape sequences anyway.

The change is really only necessary for strings that could potentially contain backslashes.  But to be safe and consistent I applied the pattern to all strings.