### PR TITLE
Remove username and password from repository URL

### DIFF
--- a/src/GitInfo/build/GitInfo.targets
+++ b/src/GitInfo/build/GitInfo.targets
@@ -377,6 +377,11 @@
 		<Warning Condition="'$(MSBuildLastExitCode)' != '0'"
 				 Text="Could not retrieve repository url for remote '$(GitRemote)'" />
 
+		<PropertyGroup>
+			<!-- Remove username and password from repository URL -->
+			<GitRepositoryUrl>$([System.Text.RegularExpressions.Regex]::Replace($(GitRepositoryUrl), "://[^/]*@", "://"))</GitRepositoryUrl>
+		</PropertyGroup>
+
 		<!--TODO: Sensible default for GitRepositoryUrl-->
 	</Target>
 


### PR DESCRIPTION
This fixed #122 by replacing the pattern `://[^/]*@` with `://` in the repository URL.  If the URL contained a username and/or password this this will strip them.  This helps to avoid leaking passwords or tokens.